### PR TITLE
Fix three codebase bugs

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -221,7 +221,8 @@ Future<void> main() async {
       GoRoute(
         path: '/game/:id',
         builder: (context, state) {
-          final gameId = int.parse(state.pathParameters['id']!);
+          final gameId = int.tryParse(state.pathParameters['id'] ?? '');
+          if (gameId == null) return const NotFoundScreen();
           final gameData = state.extra as Map<String, dynamic>?;
 
           return GameScreen(
@@ -234,15 +235,21 @@ Future<void> main() async {
       ),
       GoRoute(
         path: '/tournament/:id',
-        builder: (c, s) => TournamentOverviewScreen(
-            tournamentId: int.parse(s.pathParameters['id']!)),
+        builder: (c, s) {
+          final tournamentId = int.tryParse(s.pathParameters['id'] ?? '');
+          if (tournamentId == null) return const NotFoundScreen();
+          return TournamentOverviewScreen(tournamentId: tournamentId);
+        },
         redirect: (ctx, state) =>
             ctx.read<AuthProvider>().isAuthenticated ? null : '/login',
       ),
       GoRoute(
         path: '/tournament/:id/leaderboard',
-        builder: (c, s) => LeaderboardScreen(
-            tournamentId: int.parse(s.pathParameters['id']!)),
+        builder: (c, s) {
+          final tournamentId = int.tryParse(s.pathParameters['id'] ?? '');
+          if (tournamentId == null) return const NotFoundScreen();
+          return LeaderboardScreen(tournamentId: tournamentId);
+        },
         redirect: (ctx, state) =>
         ctx.read<AuthProvider>().isAuthenticated ? null : '/login',
       ),

--- a/lib/services/auth_api.dart
+++ b/lib/services/auth_api.dart
@@ -40,7 +40,7 @@ class AuthApi {
   Future<ApiResult<String?>> sendOtp(String phone) async {
     try {
       final resp = await http
-          .post(Uri.parse('$baseUrl/auth/signup'),
+          .post(Uri.parse('$baseUrl/auth/send-otp'),
           headers: {'Content-Type': 'application/json'},
           body: jsonEncode({'phone_number': phone}))
           .timeout(const Duration(seconds: 5));
@@ -188,7 +188,7 @@ class AuthApi {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer $token',
         },
-      );
+      ).timeout(const Duration(seconds: 5));
 
       if (resp.statusCode == 200) {
         return ApiResult.success(


### PR DESCRIPTION
Fix 3 bugs: unsafe integer parsing, incorrect OTP endpoint, and missing API timeout.

This PR addresses three distinct issues:
1.  **Unsafe integer parsing**: Replaced `int.parse()` with `int.tryParse()` for path parameters in `main.dart` to prevent app crashes when invalid IDs are provided in URLs, redirecting to `NotFoundScreen` instead.
2.  **Incorrect API endpoint**: Corrected the `sendOtp()` method in `auth_api.dart` to use the `/auth/send-otp` endpoint instead of `/auth/signup`.
3.  **Missing API timeout**: Added a 5-second timeout to the `getMe()` API call in `auth_api.dart` to prevent the app from hanging indefinitely on unresponsive servers.

---
<a href="https://cursor.com/background-agent?bcId=bc-7428cc18-3c6e-4668-8a3c-fedeca7c0fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7428cc18-3c6e-4668-8a3c-fedeca7c0fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>